### PR TITLE
add: devcontainer files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+# Pre-built Dev Container Image for R. More info: https://github.com/rocker-org/devcontainer-images/pkgs/container/devcontainer%2Ftidyverse
+# Available R version: 4, 4.1, 4.0
+ARG VARIANT="4.2"
+FROM ghcr.io/rocker-org/devcontainer/tidyverse:${VARIANT}
+
+RUN install2.r --error --skipinstalled -n -1 \
+        statip \
+        patchwork \
+        paletteer \
+        here \
+        doParallel \
+        janitor \
+        vip \
+        ranger \
+        palmerpenguins \
+        skimr \
+        nnet \
+        kernlab \
+        plotly \
+        factoextra \
+        cluster \
+        tidymodels \
+        markdown \
+        ottr \
+    && rm -rf /tmp/downloaded_packages \
+    && R -q -e 'remotes::install_github("https://github.com/dcomtois/summarytools/tree/0-8-9")' \
+    && R -q -e 'remotes::install_github("ed2c/wisselstroom")' [1]
+
+# Install Python packages
+COPY requirements.txt /tmp/pip-tmp/
+RUN python3 -m pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,8 @@ RUN install2.r --error --skipinstalled -n -1 \
         palmerpenguins \
         skimr \
         nnet \
+        bezier \
+        gt \
         kernlab \
         plotly \
         factoextra \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,55 @@
+{
+	"name": "R Data Science Environment",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update VARIANT to pick a specific R version: 4, 4.1, 4.0
+		// More info: https://github.com/rocker-org/devcontainer-images/pkgs/container/devcontainer%2Ftidyverse
+		"args": { "VARIANT": "4" }
+	},
+
+	// Install Dev Container Features. More info: https://containers.dev/features
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {},
+		// Install JupyterLab and IRkernel.
+		// More info: https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver
+		"ghcr.io/rocker-org/devcontainer-features/r-rig:1": {
+			"version": "none",
+			"installJupyterlab": true
+		}
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// Add Jupyter and Python vscode extensions
+				"ms-toolsai.jupyter",
+				"ms-toolsai.jupyter-renderers",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"vsls-contrib.codetour",
+				"GitHub.copilot"
+			]
+		}
+	},
+
+	// Forward Jupyter and RStudio ports
+	"forwardPorts": [8787, 8888],
+	"portsAttributes": {
+		"8787": {
+			"label": "Rstudio",
+			"requireLocalPort": true,
+			"onAutoForward": "ignore"
+		},
+		"8888": {
+			"label": "Jupyter",
+			"requireLocalPort": true,
+			"onAutoForward": "ignore"
+		}
+	},
+
+	// Use 'postAttachCommand' to run commands after the container is started.
+	"postAttachCommand": "sudo rstudio-server start"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root
+	// "remoteUser": "root"
+}

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,14 @@
+pybryt
+pylint
+datascience
+otter-grader
+numpy
+pandas
+scipy
+folium>=0.9.1
+matplotlib
+ipywidgets>=7.0.0
+bqplot
+nbinteract>=0.0.12
+okpy
+scikit-learn


### PR DESCRIPTION
This pull request will build a devcontainer as per the instructions in the following [repository](https://github.com/revodavid/devcontainers-rstudio?tab=readme-ov-file#dev-containers-in-github-codepaces).

Following the instructions, mentioned in the link, we can access a RStudio instance with the `wisselstroom` package pre-installed.

Note: Login and password are both `rstudio`